### PR TITLE
Release audio focus on session end

### DIFF
--- a/lib/screens/exercise/exercise_step1.dart
+++ b/lib/screens/exercise/exercise_step1.dart
@@ -232,6 +232,7 @@ class _ExerciseStep1State extends State<ExerciseStep1> {
 
   @override
   void dispose() {
+    audioPlayerService.releaseAudioFocus();
     audioPlayerService.disposePlayer('bell');
     BreathingUtils.cancelBreathCycleTimer(breathCycleTimer);
 

--- a/lib/utils/audio_player_service.dart
+++ b/lib/utils/audio_player_service.dart
@@ -98,6 +98,14 @@ Future<void> play(String assetPath, double volume, String playerId) async {
     }
 
 
+  Future<void> releaseAudioFocus() async {
+    try {
+      await _session.setActive(false);
+    } catch (e) {
+      print('Error releasing audio focus: $e');
+    }
+  }
+
   void dispose() {
     _interruptionSubscription?.cancel();
     for (var player in _players.values) {

--- a/lib/widgets/animated_circle.dart
+++ b/lib/widgets/animated_circle.dart
@@ -130,9 +130,10 @@ class AnimatedCircleState extends State<AnimatedCircle>
   }
 
   @override
-  void dispose() async {
+  void dispose() {
     _controller.dispose();
 
+    audioPlayerService.releaseAudioFocus();
     audioPlayerService.disposePlayer('in');
     audioPlayerService.disposePlayer('out');
     super.dispose();


### PR DESCRIPTION
Proposed changes make the app to release the audio focus on session end.
This restores android system volume to the original level without closing the app.