### PR TITLE
chore(Linux): Add HealthFitness and Mindfulness categories to metainfo

### DIFF
--- a/metadata/io.naox.InnerBreeze.metainfo.xml
+++ b/metadata/io.naox.InnerBreeze.metainfo.xml
@@ -6,6 +6,8 @@
     <content_rating type="oars-1.1" />
     <developer_name>NaoX</developer_name>
     <categories>
+        <category>HealthFitness</category>
+        <category>Mindfulness</category>
         <category>Utility</category>
     </categories>
     <keywords>


### PR DESCRIPTION
HealthFitness can be found here: https://specifications.freedesktop.org/menu/latest/category-registry.html

Mindfulness can be found here: https://specifications.freedesktop.org/menu/latest/additional-category-registry.html